### PR TITLE
Add patches of my own

### DIFF
--- a/st.1
+++ b/st.1
@@ -3,7 +3,11 @@
 st \- simple terminal
 .SH SYNOPSIS
 .B st
-.RB [ \-aiv ]
+.RB [ \-aCirv ]
+.RB [ \-b
+.IR bordersize ]
+.RB [ \-B
+.IR bordercolor ]
 .RB [ \-c
 .IR class ]
 .RB [ \-f
@@ -27,7 +31,11 @@ st \- simple terminal
 .RI [ arguments ...]]
 .PP
 .B st
-.RB [ \-aiv ]
+.RB [ \-aCirv ]
+.RB [ \-b
+.IR bordersize ]
+.RB [ \-B
+.IR bordercolor ]
 .RB [ \-c
 .IR class ]
 .RB [ \-f
@@ -55,8 +63,17 @@ is a simple terminal emulator.
 .B \-a
 disable alternate screens in terminal
 .TP
+.BI \-b " bordersize"
+set a window border size in pixels.
+.TP
+.BI \-B " bordercolor"
+set a window border color using a hex value (without #).
+.TP
 .BI \-c " class"
 defines the window class (default $TERM).
+.TP
+.BI \-C
+try to center the st window on the screen.
 .TP
 .BI \-f " font"
 defines the

--- a/x.c
+++ b/x.c
@@ -108,6 +108,7 @@ typedef struct {
 	int override_redirect; /* set the override_redirect bit? */
 	int l, t; /* left and top offset */
 	int gm; /* geometry mask */
+	int center_window; /* whether to center the terminal window */
 } XWindow;
 
 typedef struct {
@@ -1160,6 +1161,11 @@ xinit(int cols, int rows)
 	if (xw.gm & YNegative)
 		xw.t += DisplayHeight(xw.dpy, xw.scr) - win.h - 2;
 
+	if (xw.center_window) {
+		xw.l = (DisplayWidth(xw.dpy, xw.scr) - win.w) / 2;
+		xw.t = (DisplayHeight(xw.dpy, xw.scr) - win.h) / 2;
+	}
+
 	/* Events */
 	xw.attrs.background_pixel = dc.col[defaultbg].pixel;
 	xw.attrs.border_pixel = dc.col[defaultbg].pixel;
@@ -2049,7 +2055,7 @@ int
 main(int argc, char *argv[])
 {
 	xw.l = xw.t = 0;
-	xw.override_redirect = xw.isfixed = False;
+	xw.center_window = xw.override_redirect = xw.isfixed = False;
 	xsetcursor(cursorshape);
 
 	ARGBEGIN {
@@ -2058,6 +2064,9 @@ main(int argc, char *argv[])
 		break;
 	case 'c':
 		opt_class = EARGF(usage());
+		break;
+	case 'C':
+		xw.center_window = 1;
 		break;
 	case 'e':
 		if (argc > 0)


### PR DESCRIPTION
These were cherry-picked from `old-custom`, the former `master` branch. They're
patches I've made for my own convenience, though I might choose to submit them
to the suckless mailing list at some point.

They are as follows:

**override_redirect:** Add a flag (`-r`) that makes `st` set the Override
Redirect flag to its window with X11, making it so it isn't managed by any
window manager or desktop environment, similar to how `dmenu` works.

**center window:** Makes the most sense with the above patch. Add a flag (`-C`)
that makes `st` center its window on the screen it's being mapped to. If using a
tiling window manager, you _will_ need to set the `override_redirect` bit.

**x11 borders:** Add a couple flags (`-b` and `-B`) to make `st` add X11 borders
to its window, with a flag to control what color those borders will be. A minor
quirk being that `-B`, which sets the border color, takes a color hex value
  without the `#`.
