### PR TITLE
Add personal configuration as default

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -73,8 +73,8 @@ static unsigned int cursorthickness = 2;
  *    Bold affects lines thickness if boxdraw_bold is not 0. Italic is ignored.
  * 0: disable (render all U25XX glyphs normally from the font).
  */
-const int boxdraw = 0;
-const int boxdraw_bold = 0;
+const int boxdraw = 1;
+const int boxdraw_bold = 1;
 
 /* braille (U28XX):  1: render as adjacent "pixels",  0: use font */
 const int boxdraw_braille = 0;

--- a/config.def.h
+++ b/config.def.h
@@ -5,8 +5,8 @@
  *
  * font: see http://freedesktop.org/software/fontconfig/fontconfig-user.html
  */
-static char *font = "Liberation Mono:pixelsize=12:antialias=true:autohint=true";
-static int borderpx = 2;
+static char *font = "DejaVu Sans Mono:size=9.1:antialias=true:autohint=true";
+static int borderpx = 3;
 
 /*
  * What program is execed by st depends of these precedence rules:

--- a/config.def.h
+++ b/config.def.h
@@ -153,7 +153,7 @@ static unsigned int defaultrcs = 257;
  * 6: Bar ("|")
  * 7: Snowman ("☃")
  */
-static unsigned int cursorshape = 2;
+static unsigned int cursorshape = 4;
 
 /*
  * Default columns and rows numbers

--- a/config.def.h
+++ b/config.def.h
@@ -108,32 +108,28 @@ unsigned int tabspaces = 8;
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {
 	/* 8 normal colors */
-	"black",
-	"red3",
-	"green3",
-	"yellow3",
-	"blue2",
-	"magenta3",
-	"cyan3",
-	"gray90",
+	[0] = "#282a2e", /* black   */
+	[1] = "#a54242", /* red     */
+	[2] = "#8c9440", /* green   */
+	[3] = "#de935f", /* yellow  */
+	[4] = "#5f819d", /* blue    */
+	[5] = "#85678f", /* magenta */
+	[6] = "#5e8d87", /* cyan    */
+	[7] = "#707880", /* white   */
 
 	/* 8 bright colors */
-	"gray50",
-	"red",
-	"green",
-	"yellow",
-	"#5c5cff",
-	"magenta",
-	"cyan",
-	"white",
+	[8]  = "#373b41", /* black   */
+	[9]  = "#cc6666", /* red     */
+	[10] = "#b5bd68", /* green   */
+	[11] = "#f0c674", /* yellow  */
+	[12] = "#81a2be", /* blue    */
+	[13] = "#b294bb", /* magenta */
+	[14] = "#8abeb7", /* cyan    */
+	[15] = "#c5c8c6", /* white   */
 
-	[255] = 0,
-
-	/* more colors can be added after 255 to use with DefaultXX */
-	"#cccccc",
-	"#555555",
-	"gray90", /* default foreground colour */
-	"black", /* default background colour */
+	/* special colors */
+	[256] = "#1d1f21", /* background */
+	[257] = "#c5c8c6", /* foreground */
 };
 
 
@@ -141,10 +137,10 @@ static const char *colorname[] = {
  * Default colors (colorname index)
  * foreground, background, cursor, reverse cursor
  */
-unsigned int defaultfg = 258;
-unsigned int defaultbg = 259;
-unsigned int defaultcs = 256;
-static unsigned int defaultrcs = 257;
+unsigned int defaultfg = 257;
+unsigned int defaultbg = 256;
+unsigned int defaultcs = 257;
+static unsigned int defaultrcs = 256;
 
 /*
  * Default shape of cursor


### PR DESCRIPTION
Add personal configuration to `config.def.h` that will serve as default for this
version of `st`. As put in one of the commits, while this can be used by any
interested party, it's mainly meant for my personal use.

Summary of changes:

- Enabled boxdraw, which comes disabled by default in its patch.
- Changed font to DejaVu Sans Mono, size 9.1 pt.
- Set internal padding to 3 px.
- Added a nicer colorscheme, which was likely taken from
  [terminal.sexy](https://terminal.sexy).
