### PR TITLE
Explicitly return input focus to previous window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
       - name: Checkout files in the repository
         uses: actions/checkout@v3
 
+      - name: Install X11 libraries
+        run: sudo apt-get install libx11-dev libxft-dev
+
       - name: Compile st
         run: make
 

--- a/st.c
+++ b/st.c
@@ -724,6 +724,8 @@ sigchld(int a)
 		die("child exited with status %d\n", WEXITSTATUS(stat));
 	else if (WIFSIGNALED(stat))
 		die("child terminated due to signal %d\n", WTERMSIG(stat));
+
+	returnfocus();
 	_exit(0);
 }
 

--- a/st.h
+++ b/st.h
@@ -122,6 +122,8 @@ void boxdraw_xinit(Display *, Colormap, XftDraw *, Visual *);
 void drawboxes(int, int, int, int, XftColor *, XftColor *, const XftGlyphFontSpec *, int);
 #endif
 
+void returnfocus(void);
+
 /* config.h globals */
 extern char *utmp;
 extern char *scroll;

--- a/x.c
+++ b/x.c
@@ -2086,6 +2086,7 @@ void
 returnfocus(void)
 {
 	XSetInputFocus(xw.dpy, previously_focused, previously_revert, CurrentTime);
+	XCloseDisplay(xw.dpy);
 }
 
 int


### PR DESCRIPTION
Explicitly return input focus to previous window through XSetInputFocus. While
not strictly necessary, this triggers an event (I think) for programs that are
listening to them, such as Firefox, for redrawing.

Closes #6.
