### PR TITLE
Remove mapping for Shift + Space

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -810,7 +810,6 @@ static Key key[] = {
 	{ XK_space,        Mod1Mask|ControlMask,           "\033[32;7u",  0,  0},
 	{ XK_space,        Mod1Mask|ControlMask|ShiftMask, "\033[32;8u",  0,  0},
 	{ XK_space,        Mod1Mask|ShiftMask,             "\033[32;4u",  0,  0},
-	{ XK_space,        ShiftMask,                      "\033[32;2u",  0,  0},
 	{ XK_0,            ControlMask,                    "\033[48;5u",  0,  0},
 	{ XK_A,            ControlMask|ShiftMask,          "\033[65;6u",  0,  0},
 	{ XK_B,            ControlMask|ShiftMask,          "\033[66;6u",  0,  0},


### PR DESCRIPTION
Remove the mapping for Shift + Space, so it's handled as usual: space.

f265d72 introduced mappings for a ton of key combinations, to allow one to bind
combinations usually not handled by terminal emulators. This commit removes the
one for Shift + Space, as that won't ever be used by me for key bindings on
terminal programs.
