### PR TITLE
merge: sync with upstream 0.9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout files in the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install X11 libraries
         run: sudo apt-get install libx11-dev libxft-dev
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout files in the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Compile st's terminfo entry
         run: tic -sx st.info

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,7 @@ include config.mk
 SRC = st.c x.c
 OBJ = $(SRC:.c=.o)
 
-all: options st
-
-options:
-	@echo st build options:
-	@echo "CFLAGS  = $(STCFLAGS)"
-	@echo "LDFLAGS = $(STLDFLAGS)"
-	@echo "CC      = $(CC)"
+all: st
 
 config.h:
 	cp config.def.h config.h
@@ -54,4 +48,4 @@ uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/st
 	rm -f $(DESTDIR)$(MANPREFIX)/man1/st.1
 
-.PHONY: all options clean dist install uninstall
+.PHONY: all clean dist install uninstall

--- a/config.def.h
+++ b/config.def.h
@@ -53,7 +53,7 @@ int allowwindowops = 0;
  * near minlatency, but it waits longer for slow updates to avoid partial draw.
  * low minlatency will tear/flicker more, as it can "detect" idle too early.
  */
-static double minlatency = 8;
+static double minlatency = 2;
 static double maxlatency = 33;
 
 /*

--- a/config.mk
+++ b/config.mk
@@ -1,5 +1,5 @@
 # st version
-VERSION = 0.9.1
+VERSION = 0.9.2
 
 # Customize below to fit your system
 

--- a/config.mk
+++ b/config.mk
@@ -1,5 +1,5 @@
 # st version
-VERSION = 0.9
+VERSION = 0.9.1
 
 # Customize below to fit your system
 

--- a/st.c
+++ b/st.c
@@ -2471,8 +2471,10 @@ check_control_code:
 		gp = &term.line[term.c.y][term.c.x];
 	}
 
-	if (IS_SET(MODE_INSERT) && term.c.x+width < term.col)
+	if (IS_SET(MODE_INSERT) && term.c.x+width < term.col) {
 		memmove(gp+width, gp, (term.col - term.c.x - width) * sizeof(Glyph));
+		gp->mode &= ~ATTR_WIDE;
+	}
 
 	if (term.c.x+width > term.col) {
 		tnewline(1);

--- a/st.c
+++ b/st.c
@@ -2477,7 +2477,10 @@ check_control_code:
 	}
 
 	if (term.c.x+width > term.col) {
-		tnewline(1);
+		if (IS_SET(MODE_WRAP))
+			tnewline(1);
+		else
+			tmoveto(term.col - width, term.c.y);
 		gp = &term.line[term.c.y][term.c.x];
 	}
 

--- a/st.c
+++ b/st.c
@@ -1097,7 +1097,7 @@ tscrollup(int orig, int n)
 void
 selscroll(int orig, int n)
 {
-	if (sel.ob.x == -1)
+	if (sel.ob.x == -1 || sel.alt != IS_SET(MODE_ALTSCREEN))
 		return;
 
 	if (BETWEEN(sel.nb.y, orig, term.bot) != BETWEEN(sel.ne.y, orig, term.bot)) {

--- a/st.c
+++ b/st.c
@@ -2330,6 +2330,7 @@ eschandle(uchar ascii)
 		treset();
 		resettitle();
 		xloadcols();
+		xsetmode(0, MODE_HIDE);
 		break;
 	case '=': /* DECPAM -- Application keypad */
 		xsetmode(1, MODE_APPKEYPAD);

--- a/st.c
+++ b/st.c
@@ -1643,7 +1643,7 @@ csihandle(void)
 			ttywrite(vtiden, strlen(vtiden), 0);
 		break;
 	case 'b': /* REP -- if last char is printable print it <n> more times */
-		DEFAULT(csiescseq.arg[0], 1);
+		LIMIT(csiescseq.arg[0], 1, 65535);
 		if (term.lastc)
 			while (csiescseq.arg[0]-- > 0)
 				tputc(term.lastc);

--- a/st.c
+++ b/st.c
@@ -1728,6 +1728,7 @@ csihandle(void)
 		}
 		break;
 	case 'S': /* SU -- Scroll <n> line up */
+		if (csiescseq.priv) break;
 		DEFAULT(csiescseq.arg[0], 1);
 		tscrollup(term.top, csiescseq.arg[0]);
 		break;

--- a/st.c
+++ b/st.c
@@ -86,8 +86,8 @@ enum escape_state {
 
 typedef struct {
 	Glyph attr; /* current char attributes */
-	int x;
-	int y;
+	int x; /* terminal column */
+	int y; /* terminal row */
 	char state;
 } TCursor;
 
@@ -2175,12 +2175,16 @@ tstrsequence(uchar c)
 void
 tcontrolcode(uchar ascii)
 {
+	size_t i;
+
 	switch (ascii) {
 	case '\t':   /* HT */
 		tputtab(1);
 		return;
 	case '\b':   /* BS */
-		tmoveto(term.c.x-1, term.c.y);
+		for (i = 1; term.c.x && term.line[term.c.y][term.c.x - i].u == 0; ++i)
+			;
+		tmoveto(term.c.x - i, term.c.y);
 		return;
 	case '\r':   /* CR */
 		tmoveto(0, term.c.y);

--- a/st.c
+++ b/st.c
@@ -86,8 +86,8 @@ enum escape_state {
 
 typedef struct {
 	Glyph attr; /* current char attributes */
-	int x; /* terminal column */
-	int y; /* terminal row */
+	int x;
+	int y;
 	char state;
 } TCursor;
 
@@ -2175,16 +2175,12 @@ tstrsequence(uchar c)
 void
 tcontrolcode(uchar ascii)
 {
-	size_t i;
-
 	switch (ascii) {
 	case '\t':   /* HT */
 		tputtab(1);
 		return;
 	case '\b':   /* BS */
-		for (i = 1; term.c.x && term.line[term.c.y][term.c.x - i].u == 0; ++i)
-			;
-		tmoveto(term.c.x - i, term.c.y);
+		tmoveto(term.c.x-1, term.c.y);
 		return;
 	case '\r':   /* CR */
 		tmoveto(0, term.c.y);

--- a/st.info
+++ b/st.info
@@ -184,6 +184,10 @@ st-mono| simpleterm monocolor,
 # XTerm extensions
 	rmxx=\E[29m,
 	smxx=\E[9m,
+	BE=\E[?2004h,
+	BD=\E[?2004l,
+	PS=\E[200~,
+	PE=\E[201~,
 # disabled rep for now: causes some issues with older ncurses versions.
 #	rep=%p1%c\E[%p2%{1}%-%db,
 # tmux extensions, see TERMINFO EXTENSIONS in tmux(1)

--- a/x.c
+++ b/x.c
@@ -1617,6 +1617,9 @@ xseticontitle(char *p)
 	XTextProperty prop;
 	DEFAULT(p, opt_title);
 
+	if (p[0] == '\0')
+		p = opt_title;
+
 	if (Xutf8TextListToTextProperty(xw.dpy, &p, 1, XUTF8StringStyle,
 	                                &prop) != Success)
 		return;
@@ -1630,6 +1633,9 @@ xsettitle(char *p)
 {
 	XTextProperty prop;
 	DEFAULT(p, opt_title);
+
+	if (p[0] == '\0')
+		p = opt_title;
 
 	if (Xutf8TextListToTextProperty(xw.dpy, &p, 1, XUTF8StringStyle,
 	                                &prop) != Success)

--- a/x.c
+++ b/x.c
@@ -818,7 +818,7 @@ xloadcols(void)
 int
 xgetcolor(int x, unsigned char *r, unsigned char *g, unsigned char *b)
 {
-	if (!BETWEEN(x, 0, dc.collen))
+	if (!BETWEEN(x, 0, dc.collen - 1))
 		return 1;
 
 	*r = dc.col[x].color.red >> 8;
@@ -833,7 +833,7 @@ xsetcolorname(int x, const char *name)
 {
 	Color ncolor;
 
-	if (!BETWEEN(x, 0, dc.collen))
+	if (!BETWEEN(x, 0, dc.collen - 1))
 		return 1;
 
 	if (!xloadcolor(x, name, &ncolor))


### PR DESCRIPTION
- **Fix for wide character being incorrectly cleared on MODE_INSERT**
- **Makefile: remove the options target**
- **Fix bounds checks of dc.col**
- **Don't scroll selection on the other screen**
- **Fix wide glyphs breaking "nowrap" mode**
- **Unhide cursor on RIS (\033c)**
- **Add terminfo entries for bracketed paste mode**
- **csi: check for private marker in 'S' case**
- **Fix cursor move with wide glyphs**
- **set upper limit for REP escape sequence argument**
- **config.def.h: improve latency for the default configuration**
- **bump version to 0.9.1**
- **Revert "Fix cursor move with wide glyphs"**
- **Reset title when an empty title string is given**
- **bump version to 0.9.2**
