### PR TITLE
fix: prevent hangups by avoiding Xlib calls in signal handler & ignoring errors in ttyread()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+config.h
+*.o
+st

--- a/st.c
+++ b/st.c
@@ -732,7 +732,7 @@ logDebug(const char *prefix, const char *fmt, ...)
 	va_start(ap, fmt);
 
 	fprintf(logFile, "%d  ", getpid());
-	fprintf(logFile, "%s ", prefix);
+	fprintf(logFile, "[%s] ", prefix);
 	vfprintf(logFile, fmt, ap);
 
 	if (fmt[strlen(fmt) - 1] != '\n')

--- a/st.c
+++ b/st.c
@@ -876,9 +876,11 @@ ttyread(void)
 
 	switch (ret) {
 	case 0:
-		exit(0);
+		logDebug("ttyread", "ignoring EOF reached on tty\n");
+		return 0;
 	case -1:
-		die("couldn't read from shell: %s\n", strerror(errno));
+		logDebug("ttyread", "ignoring read error on tty: %s\n", strerror(errno));
+		return 0;
 	default:
 		buflen += ret;
 		written = twrite(buf, buflen, 0);

--- a/st.c
+++ b/st.c
@@ -771,7 +771,7 @@ sigchld(int a)
 
 	logDebug("sigchld", "exiting normally, or trying to\n\n");
 
-	exit(0);
+	_exit(0);
 }
 
 void

--- a/st.c
+++ b/st.c
@@ -221,6 +221,9 @@ static char base64dec_getc(const char **);
 
 static ssize_t xwrite(int, const char *, size_t);
 
+/* Globals used by signal handlers */
+volatile sig_atomic_t caught_sigchld = 0;
+
 /* Globals */
 static Term term;
 static Selection sel;
@@ -755,12 +758,6 @@ sigchld(int a)
 	if (pid != p)
 		return;
 
-	logDebug("sigchld", "passed the check, calling returnfocus");
-
-	returnfocus();
-
-	logDebug("sigchld", "returnfocus returned, running WIFEXITED and WIFSIGNALED");
-
 	if (WIFEXITED(stat) && WEXITSTATUS(stat)) {
 		logDebug("sigchld", "child exited with status %d, calling die()\n\n", WEXITSTATUS(stat));
 		die("child exited with status %d\n", WEXITSTATUS(stat));
@@ -769,9 +766,8 @@ sigchld(int a)
 		die("child terminated due to signal %d\n", WTERMSIG(stat));
 	}
 
-	logDebug("sigchld", "exiting normally, or trying to\n\n");
-
-	_exit(0);
+	logDebug("sigchld", "incrementing caught_sigchld\n\n");
+	caught_sigchld++;
 }
 
 void

--- a/st.h
+++ b/st.h
@@ -1,5 +1,6 @@
 /* See LICENSE for license details. */
 
+#include <signal.h>
 #include <stdint.h>
 #include <sys/types.h>
 
@@ -123,7 +124,6 @@ void drawboxes(int, int, int, int, XftColor *, XftColor *, const XftGlyphFontSpe
 #endif
 
 void logDebug(const char *, const char *, ...);
-void returnfocus(void);
 
 /* config.h globals */
 extern char *utmp;
@@ -142,3 +142,6 @@ extern const int boxdraw, boxdraw_bold, boxdraw_braille;
 
 /* extra command line options */
 extern unsigned short opt_debug;
+
+/* globals used by signal handlers */
+extern volatile sig_atomic_t caught_sigchld;

--- a/st.h
+++ b/st.h
@@ -124,6 +124,7 @@ void drawboxes(int, int, int, int, XftColor *, XftColor *, const XftGlyphFontSpe
 #endif
 
 void logDebug(const char *, const char *, ...);
+int childisdead(void);
 
 /* config.h globals */
 extern char *utmp;

--- a/x.c
+++ b/x.c
@@ -2080,18 +2080,13 @@ run(void)
 		XFlush(xw.dpy);
 		drawing = 0;
 
-		if (caught_sigchld > 0) {
-			logDebug("run", "caught SIGCHLD, breaking out of the main loop");
-			if (childisdead())
-				break;
-			else
-				caught_sigchld = 0;
-		} else {
-			logDebug("run", "caught_sigchld is still %d", caught_sigchld);
-		}
+		if (caught_sigchld > 0 && childisdead())
+			break;
+		else
+			caught_sigchld = 0;
 	}
 
-	logDebug("run", "caught SIGCHLD, got out of the main loop");
+	logDebug("run", "out of the main loop");
 
 	/*
 	 * Return focus to the window previously focused before st was started,

--- a/x.c
+++ b/x.c
@@ -2058,7 +2058,7 @@ run(void)
 			}
 			timeout = (maxlatency - TIMEDIFF(now, trigger)) \
 			          / maxlatency * minlatency;
-			if (timeout > 0)
+			if (timeout > 0 && !caught_sigchld)
 				continue;  /* we have time, try to find idle */
 		}
 

--- a/x.c
+++ b/x.c
@@ -2008,7 +2008,7 @@ run(void)
 	ttyfd = ttynew(opt_line, shell, opt_io, opt_cmd);
 	cresize(w, h);
 
-	for (timeout = -1, drawing = 0, lastblink = (struct timespec){0}; caught_sigchld < 1;) {
+	for (timeout = -1, drawing = 0, lastblink = (struct timespec){0};;) {
 		FD_ZERO(&rfd);
 		FD_SET(ttyfd, &rfd);
 		FD_SET(xfd, &rfd);
@@ -2079,6 +2079,16 @@ run(void)
 		draw();
 		XFlush(xw.dpy);
 		drawing = 0;
+
+		if (caught_sigchld > 0) {
+			logDebug("run", "caught SIGCHLD, breaking out of the main loop");
+			if (childisdead())
+				break;
+			else
+				caught_sigchld = 0;
+		} else {
+			logDebug("run", "caught_sigchld is still %d", caught_sigchld);
+		}
 	}
 
 	logDebug("run", "caught SIGCHLD, got out of the main loop");


### PR DESCRIPTION
These changes attempt to fix a long standing problem thought to have previously been addressed in #12 (closing #10), which has haunted me since before #10 was created. The changes are summarized as follows:

1. Previously, an Xlib function call was made within our handler for `SIGCHLD`. Xlib is known not to be thread safe, so the assumption here was that perhaps a race condition had been introduced if `SIGCHLD` was captured in the middle of another Xlib call. To mitigate this, we make the same Xlib function calls from the program's main loop upon interruption now.

2. The overall logic in the signal handler was more complicated than what one might be comfortable with, so it was moved out of the handler.

3. A `sig_atomic_t` was created for the signal handler to convey to st's main loop that we caught `SIGCHLD` and have to gracefully exit.

4. An input/output error was causing a call to `die()` in the `ttyread()` function, which reads from the executed command's file descriptor even after the child process has been terminated. I couldn't figure out why exactly the file descriptor is set to be ready to be read from, so instead chose to emit a debug message and ignore the errors in `ttyread()`.

5. The logic for seeking idle time or latency exhaustion was adjusted to not wait when the `SIGCHLD` signal is known to have been caught.

Thoughts writing these lines:

> Will these changes finally bring forth the end of this problem that has haunted me for so long?
