### PR TITLE
fix: avoid cursor blink by exiting before drawing

### DIFF
--- a/x.c
+++ b/x.c
@@ -2076,14 +2076,14 @@ run(void)
 			}
 		}
 
-		draw();
-		XFlush(xw.dpy);
-		drawing = 0;
-
 		if (caught_sigchld > 0 && childisdead())
 			break;
 		else
 			caught_sigchld = 0;
+
+		draw();
+		XFlush(xw.dpy);
+		drawing = 0;
 	}
 
 	logDebug("run", "out of the main loop");


### PR DESCRIPTION
If we capture `SIGCHLD`, exit before drawing the terminal again.

This avoid a cursor blink on the terminal window and lets us close the terminal window early.
