### PR TITLE
fix: support centering with multiple screens

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -18,7 +18,8 @@ INCS = -I$(X11INC) \
        `$(PKG_CONFIG) --cflags freetype2`
 LIBS = -L$(X11LIB) -lm -lrt -lX11 -lutil -lXft \
        `$(PKG_CONFIG) --libs fontconfig` \
-       `$(PKG_CONFIG) --libs freetype2`
+       `$(PKG_CONFIG) --libs freetype2` \
+       -lXinerama
 
 # flags
 STCPPFLAGS = -DVERSION=\"$(VERSION)\" -D_XOPEN_SOURCE=600


### PR DESCRIPTION
Support centering the window when multiple screens are attached to the X11 display server. This is for when Xinerama is being used to create a virtual screen that spans multiple physical monitors.
