### PR TITLE
ci: install xinerama to fix compile step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install X11 libraries
-        run: sudo apt-get install libx11-dev libxft-dev
+        run: sudo apt-get install libx11-dev libxft-dev libxinerama-dev
 
       - name: Compile st
         run: make


### PR DESCRIPTION
Install the Xinerama headers to fix the compile step in the CI workflow.
